### PR TITLE
chore: rename package

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,20 +15,20 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/libp2p/js-libp2p-railing.git"
+    "url": "https://github.com/libp2p/js-libp2p-bootstrap.git"
   },
   "keywords": [
     "IPFS"
   ],
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/libp2p/js-ipfs-railing/issues"
+    "url": "https://github.com/libp2p/js-ipfs-bootstrap/issues"
   },
   "engines": {
     "node": ">=6.0.0",
     "npm": ">=3.0.0"
   },
-  "homepage": "https://github.com/libp2p/js-ipfs-railing",
+  "homepage": "https://github.com/libp2p/js-ipfs-bootstrap",
   "devDependencies": {
     "aegir": "^14.0.0",
     "chai": "^4.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "libp2p-bootstrap",
-  "version": "0.0.0",
+  "version": "0.9.2",
   "description": "Node.js IPFS Implementation of the railing process of a Node through a bootstrap peer list",
   "leadMaintainer": "Vasco Santos <vasco.santos@moxy.studio>",
   "main": "src/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "libp2p-railing",
-  "version": "0.9.2",
+  "name": "libp2p-bootstrap",
+  "version": "0.0.0",
   "description": "Node.js IPFS Implementation of the railing process of a Node through a bootstrap peer list",
   "leadMaintainer": "Vasco Santos <vasco.santos@moxy.studio>",
   "main": "src/index.js",


### PR DESCRIPTION
I think that it makes sense to reset the package version. But, I don't know the usual procedure here. This way, I can also keep the same version if you usually do it this way.

Once this is merged, tasks that need to be done:

- [ ] deprecate `libp2p-railing`
- [ ] publish minor version of `libp2p-bootstrap`
- [x] change github repo name

Commands:
`npm deprecate libp2p-railing@0.9.2 "WARNING: This project has been renamed to libp2p-bootstrap. Install using libp2p-bootstrap instead."`

Closes #67 