### PR TITLE
perf: create and cache peer infos once on start

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,5 @@ test/test-data/go-ipfs-repo/LOG.old
 
 # while testing npm5
 package-lock.json
+
+.nyc_output

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
   "devDependencies": {
     "aegir": "^14.0.0",
     "chai": "^4.1.2",
+    "dirty-chai": "^2.0.1",
     "libp2p-tcp": "~0.12.0"
   },
   "dependencies": {


### PR DESCRIPTION
The list never changes so no need to recompute each time. Also removes unnecessary async peer info create - only required if creating a Peer ID (which we already have).

Also has the nice side effect of not logging an error every 10 seconds if you have an invalid multiaddr in your bootstrap list.

I also made the tests better by collecting all the peers emitted and then ensuring we got the right number of peers...and made them faster by decreasing the intervals ;)