### PR TITLE
refactor: callbacks -> async/await

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   },
   "devDependencies": {
     "aegir": "^18.2.1",
-    "chai": "^4.2.0",
+    "chai": "^4.2.0"
   },
   "dependencies": {
     "debug": "^4.1.1",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "npm": ">=3.0.0"
   },
   "devDependencies": {
-    "aegir": "^18.2.1",
+    "aegir": "^20.0.0",
     "chai": "^4.2.0"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -35,8 +35,8 @@
     "debug": "^4.1.1",
     "mafmt": "^6.0.6",
     "multiaddr": "^6.0.4",
-    "peer-id": "libp2p/js-peer-id#feat/async-await",
-    "peer-info": "libp2p/js-peer-info#feat/async-await"
+    "peer-id": "^0.13.2",
+    "peer-info": "^0.16.0"
   },
   "pre-push": [
     "lint",

--- a/package.json
+++ b/package.json
@@ -29,16 +29,14 @@
   },
   "devDependencies": {
     "aegir": "^18.1.1",
-    "chai": "^4.2.0",
-    "libp2p-tcp": "~0.13.0"
+    "chai": "^4.2.0"
   },
   "dependencies": {
-    "async": "^2.6.2",
     "debug": "^4.1.1",
     "mafmt": "^6.0.6",
     "multiaddr": "^6.0.4",
-    "peer-id": "~0.12.2",
-    "peer-info": "~0.15.1"
+    "peer-id": "libp2p/js-peer-id#feat/async-await",
+    "peer-info": "libp2p/js-peer-info#feat/async-await"
   },
   "pre-push": [
     "lint",

--- a/src/index.js
+++ b/src/index.js
@@ -11,20 +11,6 @@ const log = debug('libp2p:bootstrap')
 log.error = debug('libp2p:bootstrap:error')
 
 /**
- * Indicates if an address is in IPFS multi-address format.
- *
- * @param {string} addr
- * @returns {boolean}
- */
-function isIPFS (addr) {
-  try {
-    return mafmt.IPFS.matches(addr)
-  } catch (e) {
-    return false
-  }
-}
-
-/**
  * Emits 'peer' events on a regular interval for each peer in the provided list.
  */
 class Bootstrap extends EventEmitter {
@@ -61,7 +47,7 @@ class Bootstrap extends EventEmitter {
    */
   _discoverBootstrapPeers () {
     this._list.forEach(async (candidate) => {
-      if (!isIPFS(candidate)) {
+      if (!mafmt.IPFS.matches(candidate)) {
         return log.error('Invalid multiaddr')
       }
 

--- a/src/index.js
+++ b/src/index.js
@@ -10,6 +10,12 @@ const debug = require('debug')
 const log = debug('libp2p:bootstrap')
 log.error = debug('libp2p:bootstrap:error')
 
+/**
+ * Indicates if an address is in IPFS multi-address format.
+ *
+ * @param {string} addr
+ * @returns {boolean}
+ */
 function isIPFS (addr) {
   try {
     return mafmt.IPFS.matches(addr)
@@ -18,7 +24,18 @@ function isIPFS (addr) {
   }
 }
 
+/**
+ * Emits 'peer' events on a regular interval for each peer in the provided list.
+ */
 class Bootstrap extends EventEmitter {
+  /**
+   * Constructs a new Bootstrap.
+   *
+   * @param {Object} options
+   * @param {Array<string>} options.list - the list of peer addresses in multi-address format
+   * @param {number} options.interval - the interval between emitting addresses
+   *
+   */
   constructor (options) {
     super()
     this._list = options.list
@@ -26,6 +43,9 @@ class Bootstrap extends EventEmitter {
     this._timer = null
   }
 
+  /**
+   * Start emitting events.
+   */
   start () {
     if (this._timer) {
       return
@@ -36,6 +56,9 @@ class Bootstrap extends EventEmitter {
     this._discoverBootstrapPeers()
   }
 
+  /**
+   * Emit each address in the list as a PeerInfo.
+   */
   _discoverBootstrapPeers () {
     this._list.forEach(async (candidate) => {
       if (!isIPFS(candidate)) {
@@ -56,6 +79,9 @@ class Bootstrap extends EventEmitter {
     })
   }
 
+  /**
+   * Stop emitting events.
+   */
   stop () {
     if (this._timer) {
       clearInterval(this._timer)

--- a/src/index.js
+++ b/src/index.js
@@ -19,7 +19,7 @@ class Bootstrap extends EventEmitter {
    *
    * @param {Object} options
    * @param {Array<string>} options.list - the list of peer addresses in multi-address format
-   * @param {number} options.interval - the interval between emitting addresses
+   * @param {number} options.interval - the interval between emitting addresses (in milli-seconds)
    *
    */
   constructor (options) {

--- a/test/bootstrap.spec.js
+++ b/test/bootstrap.spec.js
@@ -8,18 +8,19 @@ const { expect } = require('chai')
 const mafmt = require('mafmt')
 
 describe('bootstrap', () => {
-  it('find the other peer', function (done) {
+  it('find the other peer', function () {
     this.timeout(5 * 1000)
     const r = new Bootstrap({
       list: peerList,
       interval: 2000
     })
 
-    r.once('peer', (peer) => done())
-    r.start(() => {})
+    const p = new Promise((resolve) => r.once('peer', resolve))
+    r.start()
+    return p
   })
 
-  it('not fail on malformed peers in peer list', function (done) {
+  it('not fail on malformed peers in peer list', function () {
     this.timeout(5 * 1000)
 
     const r = new Bootstrap({
@@ -27,13 +28,17 @@ describe('bootstrap', () => {
       interval: 2000
     })
 
-    r.start(() => { })
-
-    r.on('peer', (peer) => {
-      const peerList = peer.multiaddrs.toArray()
-      expect(peerList.length).to.eq(1)
-      expect(mafmt.IPFS.matches(peerList[0].toString()))
-      done()
+    const p = new Promise((resolve) => {
+      r.on('peer', (peer) => {
+        const peerList = peer.multiaddrs.toArray()
+        expect(peerList.length).to.eq(1)
+        expect(mafmt.IPFS.matches(peerList[0].toString()))
+        resolve()
+      })
     })
+
+    r.start()
+
+    return p
   })
 })


### PR DESCRIPTION
BREAKING CHANGE: All places in the API that used callbacks are now replaced with async/await

Depends on:
- [x] https://github.com/libp2p/js-peer-id/pull/87
- [x] https://github.com/libp2p/js-peer-info/pull/67