### PR TITLE
chore: add discourse badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ js-libp2p-bootstrap
 [![](https://img.shields.io/badge/made%20by-Protocol%20Labs-blue.svg?style=flat-square)](http://protocol.ai)
 [![](https://img.shields.io/badge/project-libp2p-yellow.svg?style=flat-square)](http://libp2p.io/)
 [![](https://img.shields.io/badge/freenode-%23libp2p-yellow.svg?style=flat-square)](http://webchat.freenode.net/?channels=%23libp2p)
+[![Discourse posts](https://img.shields.io/discourse/https/discuss.libp2p.io/posts.svg)](https://discuss.libp2p.io)
 [![](https://img.shields.io/codecov/c/github/libp2p/js-libp2p-bootstrap.svg?style=flat-square)](https://codecov.io/gh/libp2p/js-libp2p-bootstrap)
 [![](https://img.shields.io/travis/libp2p/js-libp2p-bootstrap.svg?style=flat-square)](https://travis-ci.com/libp2p/js-libp2p-bootstrap)
 [![js-standard-style](https://img.shields.io/badge/code%20style-standard-brightgreen.svg?style=flat-square)](https://github.com/feross/standard)

--- a/package.json
+++ b/package.json
@@ -28,15 +28,15 @@
     "npm": ">=3.0.0"
   },
   "devDependencies": {
-    "aegir": "^18.1.1",
+    "aegir": "^18.2.1",
     "chai": "^4.2.0",
     "libp2p-tcp": "~0.13.0"
   },
   "dependencies": {
     "async": "^2.6.2",
     "debug": "^4.1.1",
-    "mafmt": "^6.0.6",
-    "multiaddr": "^6.0.4",
+    "mafmt": "^6.0.7",
+    "multiaddr": "^6.0.6",
     "peer-id": "~0.12.2",
     "peer-info": "~0.15.1"
   },


### PR DESCRIPTION
In the context of [libp2p/libp2p#74](https://github.com/libp2p/libp2p/issues/74), the badge for [discuss.libp2p.io](http://discuss.libp2p.io) was added.

Dependencies were also updated