### PR TITLE
chore: peer-discovery not using peer-info

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "aegir": "^21.2.0",
     "chai": "^4.2.0",
     "dirty-chai": "^2.0.1",
-    "libp2p-interfaces": "libp2p/js-interfaces#v0.3.x"
+    "libp2p-interfaces": "^0.3.0"
   },
   "dependencies": {
     "debug": "^4.1.1",

--- a/package.json
+++ b/package.json
@@ -36,8 +36,7 @@
     "debug": "^4.1.1",
     "mafmt": "^7.0.0",
     "multiaddr": "^7.2.1",
-    "peer-id": "^0.13.5",
-    "peer-info": "^0.17.0"
+    "peer-id": "^0.13.5"
   },
   "pre-push": [
     "lint",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
   "devDependencies": {
     "aegir": "^21.2.0",
     "chai": "^4.2.0",
-    "dirty-chai": "^2.0.1"
+    "dirty-chai": "^2.0.1",
+    "libp2p-interfaces": "libp2p/js-interfaces#v0.3.x"
   },
   "dependencies": {
     "debug": "^4.1.1",

--- a/src/index.js
+++ b/src/index.js
@@ -49,6 +49,10 @@ class Bootstrap extends EventEmitter {
    * Emit each address in the list as a PeerInfo.
    */
   _discoverBootstrapPeers () {
+    if (!this._timer) {
+      return
+    }
+
     this._list.forEach((candidate) => {
       if (!mafmt.P2P.matches(candidate)) {
         return log.error('Invalid multiaddr')
@@ -73,10 +77,8 @@ class Bootstrap extends EventEmitter {
    * Stop emitting events.
    */
   stop () {
-    if (this._timer) {
-      clearInterval(this._timer)
-      this._timer = null
-    }
+    clearInterval(this._timer)
+    this._timer = null
   }
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,6 @@
 'use strict'
 
 const PeerId = require('peer-id')
-const PeerInfo = require('peer-info')
 const multiaddr = require('multiaddr')
 const mafmt = require('mafmt')
 const { EventEmitter } = require('events')
@@ -50,7 +49,7 @@ class Bootstrap extends EventEmitter {
    * Emit each address in the list as a PeerInfo.
    */
   _discoverBootstrapPeers () {
-    this._list.forEach(async (candidate) => {
+    this._list.forEach((candidate) => {
       if (!mafmt.P2P.matches(candidate)) {
         return log.error('Invalid multiaddr')
       }
@@ -60,9 +59,10 @@ class Bootstrap extends EventEmitter {
       const peerId = PeerId.createFromB58String(ma.getPeerId())
 
       try {
-        const peerInfo = await PeerInfo.create(peerId)
-        peerInfo.multiaddrs.add(ma)
-        this.emit('peer', peerInfo)
+        this.emit('peer', {
+          id: peerId,
+          multiaddrs: [ma]
+        })
       } catch (err) {
         log.error('Invalid bootstrap peer id', err)
       }

--- a/test/bootstrap.spec.js
+++ b/test/bootstrap.spec.js
@@ -5,10 +5,12 @@ const chai = require('chai')
 chai.use(require('dirty-chai'))
 const { expect } = chai
 
+const mafmt = require('mafmt')
+const PeerId = require('peer-id')
+
 const Bootstrap = require('../src')
 const peerList = require('./default-peers')
 const partialValidPeerList = require('./some-invalid-peers')
-const mafmt = require('mafmt')
 
 describe('bootstrap', () => {
   it('should throw if no peer list is provided', () => {
@@ -42,10 +44,11 @@ describe('bootstrap', () => {
     })
 
     const p = new Promise((resolve) => {
-      r.once('peer', (peer) => {
-        const peerList = peer.multiaddrs.toArray()
-        expect(peerList.length).to.eq(1)
-        expect(mafmt.IPFS.matches(peerList[0].toString())).equals(true)
+      r.once('peer', ({ id, multiaddrs }) => {
+        expect(id).to.exist()
+        expect(PeerId.isPeerId(id)).to.eql(true)
+        expect(multiaddrs.length).to.eq(1)
+        expect(mafmt.IPFS.matches(multiaddrs[0].toString())).equals(true)
         resolve()
       })
     })

--- a/test/compliance.spec.js
+++ b/test/compliance.spec.js
@@ -1,0 +1,21 @@
+'use strict'
+
+/* eslint-env mocha */
+
+const tests = require('libp2p-interfaces/src/peer-discovery/tests')
+
+const Bootstrap = require('../src')
+const peerList = require('./default-peers')
+
+describe('compliance tests', () => {
+  tests({
+    setup () {
+      const bootstrap = new Bootstrap({
+        list: peerList,
+        interval: 2000
+      })
+
+      return bootstrap
+    }
+  })
+})


### PR DESCRIPTION
In the context of deprecating `peer-info` as described on [libp2p/js-libp2p#589](https://github.com/libp2p/js-libp2p/issues/589), this PR changes the `peer-discovery` interface to emit an object containing an `id` property and a `multiaddrs` property.

This PR also adds the new `peer-discovery` interface tests

BREAKING CHANGE: peer event emits an object with id and multiaddr instead of a peer-info

Needs:

- [x] [libp2p/js-libp2p-interfaces#41](https://github.com/libp2p/js-libp2p-interfaces/pull/41)