### PR TITLE
fix: replace node buffers with uint8arrays

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,16 +28,14 @@
     "npm": ">=3.0.0"
   },
   "devDependencies": {
-    "aegir": "^22.0.0",
-    "chai": "^4.2.0",
-    "dirty-chai": "^2.0.1",
-    "libp2p-interfaces": "^0.3.0"
+    "aegir": "^25.0.0",
+    "libp2p-interfaces": "^0.4.0"
   },
   "dependencies": {
     "debug": "^4.1.1",
     "mafmt": "^7.0.0",
-    "multiaddr": "^7.2.1",
-    "peer-id": "^0.13.5"
+    "multiaddr": "^8.0.0",
+    "peer-id": "^0.14.0"
   },
   "pre-push": [
     "lint",

--- a/test/bootstrap.spec.js
+++ b/test/bootstrap.spec.js
@@ -1,9 +1,7 @@
 'use strict'
 /* eslint-env mocha */
 
-const chai = require('chai')
-chai.use(require('dirty-chai'))
-const { expect } = chai
+const { expect } = require('aegir/utils/chai')
 
 const mafmt = require('mafmt')
 const PeerId = require('peer-id')


### PR DESCRIPTION
Removes redundant deps and updates everything to the latest versions.

BREAKING CHANGES:

- The deps of this module have Uint8Array properties