### PR TITLE
fix!: only discover bootstrap peers once and tag them on discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,15 @@ $ npm i @libp2p/bootstrap
 
 ## Usage
 
+The configured bootstrap peers will be discovered after the configured timeout. This will ensure
+there are some peers in the peer store for the node to use to discover other peers.
+
+They will be tagged with a tag with the name `'bootstrap'` tag, the value `50` and it will expire
+after two minutes which means the nodes connections may be closed if the maximum number of
+connections is reached.
+
+Clients that need constant connections to bootstrap nodes (e.g. browsers) can set the TTL to `Infinity`.
+
 ```JavaScript
 const Libp2p = require('libp2p')
 const Bootstrap = require('libp2p-bootstrap')
@@ -45,9 +54,11 @@ let options = {
                   "/ip4/104.131.131.82/tcp/4001/ipfs/QmaCpDMGvV2BGHeYERUEnRQAwe3N8SzbUtfsmvsqQLuvuJ",
                   "/dnsaddr/bootstrap.libp2p.io/ipfs/QmNnooDu7bfjPFoTZYxMNLWUQJyrVwtbZg5gBMjTezGAJN",
                   "/dnsaddr/bootstrap.libp2p.io/ipfs/QmQCU2EcMqAqQPR2i9bChDtGNJchTbq5TbXJJ16u19uLTa"
-                  ],
-                  interval: 5000 // default is 10 ms,
-                  enabled: true
+                ],
+                timeout: 1000, // in ms,
+                tagName: 'bootstrap',
+                tagValue: 50,
+                tagTTL: 120000 // in ms
             }
         }
     }

--- a/README.md
+++ b/README.md
@@ -34,38 +34,39 @@ connections is reached.
 Clients that need constant connections to bootstrap nodes (e.g. browsers) can set the TTL to `Infinity`.
 
 ```JavaScript
-const Libp2p = require('libp2p')
-const Bootstrap = require('libp2p-bootstrap')
-const TCP = require('libp2p-tcp')
-const { NOISE } = require('libp2p-noise')
-const MPLEX = require('libp2p-mplex')
+import { createLibp2p } from 'libp2p'
+import { Bootstrap } from '@libp2p/bootstrap'
+import { TCP } from 'libp2p/tcp'
+import { Noise } from '@libp2p/noise'
+import { Mplex } from '@libp2p/mplex'
 
 let options = {
-    modules: {
-        transport: [ TCP ],
-        peerDiscovery: [ Bootstrap ],
-        streamMuxer: [ MPLEX ],
-        encryption: [ NOISE ]
-    },
-    config: {
-        peerDiscovery: {
-            [Bootstrap.tag]: {
-                list: [ // a list of bootstrap peer multiaddrs to connect to on node startup
-                  "/ip4/104.131.131.82/tcp/4001/ipfs/QmaCpDMGvV2BGHeYERUEnRQAwe3N8SzbUtfsmvsqQLuvuJ",
-                  "/dnsaddr/bootstrap.libp2p.io/ipfs/QmNnooDu7bfjPFoTZYxMNLWUQJyrVwtbZg5gBMjTezGAJN",
-                  "/dnsaddr/bootstrap.libp2p.io/ipfs/QmQCU2EcMqAqQPR2i9bChDtGNJchTbq5TbXJJ16u19uLTa"
-                ],
-                timeout: 1000, // in ms,
-                tagName: 'bootstrap',
-                tagValue: 50,
-                tagTTL: 120000 // in ms
-            }
-        }
-    }
+  transports: [
+    new TCP()
+  ],
+  streamMuxers: [
+    new Mplex()
+  ],
+  connectionEncryption: [
+    new Noise()
+  ],
+  peerDiscovery: [
+    new Bootstrap({
+      list: [ // a list of bootstrap peer multiaddrs to connect to on node startup
+        "/ip4/104.131.131.82/tcp/4001/ipfs/QmaCpDMGvV2BGHeYERUEnRQAwe3N8SzbUtfsmvsqQLuvuJ",
+        "/dnsaddr/bootstrap.libp2p.io/ipfs/QmNnooDu7bfjPFoTZYxMNLWUQJyrVwtbZg5gBMjTezGAJN",
+        "/dnsaddr/bootstrap.libp2p.io/ipfs/QmQCU2EcMqAqQPR2i9bChDtGNJchTbq5TbXJJ16u19uLTa"
+      ],
+      timeout: 1000, // in ms,
+      tagName: 'bootstrap',
+      tagValue: 50,
+      tagTTL: 120000 // in ms
+    })
+  ]
 }
 
 async function start () {
-  let libp2p = await Libp2p.create(options)
+  let libp2p = await createLibp2p(options)
 
   libp2p.on('peer:discovery', function (peerId) {
     console.log('found peer: ', peerId.toB58String())

--- a/examples/try.js
+++ b/examples/try.js
@@ -1,5 +1,0 @@
-import { Bootstrap } from './../src/index.js'
-
-const b = new Bootstrap()
-
-console.log(b)

--- a/package.json
+++ b/package.json
@@ -144,13 +144,13 @@
     "@libp2p/interfaces": "^3.0.3",
     "@libp2p/logger": "^2.0.1",
     "@libp2p/peer-id": "^1.1.15",
-    "@multiformats/mafmt": "^11.0.3"
+    "@multiformats/mafmt": "^11.0.3",
+    "@multiformats/multiaddr": "^11.0.0"
   },
   "devDependencies": {
     "@libp2p/interface-peer-discovery-compliance-tests": "^1.0.2",
     "@libp2p/interface-peer-id": "^1.0.4",
     "@libp2p/peer-store": "^3.1.5",
-    "@multiformats/multiaddr": "^11.0.0",
     "aegir": "^37.5.3",
     "datastore-core": "^8.0.1",
     "delay": "^5.0.0"

--- a/package.json
+++ b/package.json
@@ -138,17 +138,21 @@
     "release": "aegir release"
   },
   "dependencies": {
+    "@libp2p/components": "^2.0.0",
     "@libp2p/interface-peer-discovery": "^1.0.1",
     "@libp2p/interface-peer-info": "^1.0.3",
     "@libp2p/interfaces": "^3.0.3",
-    "@libp2p/logger": "^2.0.0",
+    "@libp2p/logger": "^2.0.1",
     "@libp2p/peer-id": "^1.1.15",
-    "@multiformats/mafmt": "^11.0.3",
-    "@multiformats/multiaddr": "^11.0.0"
+    "@multiformats/mafmt": "^11.0.3"
   },
   "devDependencies": {
     "@libp2p/interface-peer-discovery-compliance-tests": "^1.0.2",
     "@libp2p/interface-peer-id": "^1.0.4",
-    "aegir": "^37.5.3"
+    "@libp2p/peer-store": "^3.1.5",
+    "@multiformats/multiaddr": "^11.0.0",
+    "aegir": "^37.5.3",
+    "datastore-core": "^8.0.1",
+    "delay": "^5.0.0"
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,8 +6,14 @@ import type { PeerDiscovery, PeerDiscoveryEvents } from '@libp2p/interface-peer-
 import type { PeerInfo } from '@libp2p/interface-peer-info'
 import { peerIdFromString } from '@libp2p/peer-id'
 import { symbol } from '@libp2p/interface-peer-discovery'
+import { Components, Initializable } from '@libp2p/components'
 
 const log = logger('libp2p:bootstrap')
+
+const DEFAULT_BOOTSTRAP_TAG_NAME = 'bootstrap'
+const DEFAULT_BOOTSTRAP_TAG_VALUE = 50
+const DEFAULT_BOOTSTRAP_TAG_TTL = 120000
+const DEFAULT_BOOTSTRAP_DISCOVERY_TIMEOUT = 1000
 
 export interface BootstrapOptions {
   /**
@@ -16,20 +22,37 @@ export interface BootstrapOptions {
   list: string[]
 
   /**
-   * The interval between emitting addresses in milliseconds
+   * How long to wait before discovering bootstrap nodes
    */
-  interval?: number
+  timeout?: number
+
+  /**
+   * Tag a bootstrap peer with this name before "discovering" it (default: 'bootstrap')
+   */
+  tagName?: string
+
+  /**
+   * The bootstrap peer tag will have this value (default: 50)
+   */
+  tagValue?: number
+
+  /**
+   * Cause the bootstrap peer tag to be removed after this number of ms (default: 2 minutes)
+   */
+  tagTTL?: number
 }
 
 /**
  * Emits 'peer' events on a regular interval for each peer in the provided list.
  */
-export class Bootstrap extends EventEmitter<PeerDiscoveryEvents> implements PeerDiscovery {
+export class Bootstrap extends EventEmitter<PeerDiscoveryEvents> implements PeerDiscovery, Initializable {
   static tag = 'bootstrap'
 
-  private timer?: ReturnType<typeof setInterval>
+  private timer?: ReturnType<typeof setTimeout>
   private readonly list: PeerInfo[]
-  private readonly interval: number
+  private readonly timeout: number
+  private components: Components = new Components()
+  private readonly _init: BootstrapOptions
 
   constructor (options: BootstrapOptions = { list: [] }) {
     if (options.list == null || options.list.length === 0) {
@@ -37,7 +60,7 @@ export class Bootstrap extends EventEmitter<PeerDiscoveryEvents> implements Peer
     }
     super()
 
-    this.interval = options.interval ?? 10000
+    this.timeout = options.timeout ?? DEFAULT_BOOTSTRAP_DISCOVERY_TIMEOUT
     this.list = []
 
     for (const candidate of options.list) {
@@ -62,6 +85,12 @@ export class Bootstrap extends EventEmitter<PeerDiscoveryEvents> implements Peer
 
       this.list.push(peerData)
     }
+
+    this._init = options
+  }
+
+  init (components: Components) {
+    this.components = components
   }
 
   get [symbol] (): true {
@@ -80,26 +109,40 @@ export class Bootstrap extends EventEmitter<PeerDiscoveryEvents> implements Peer
    * Start emitting events
    */
   start () {
-    if (this.timer != null) {
+    if (this.isStarted()) {
       return
     }
 
-    this.timer = setInterval(() => this._discoverBootstrapPeers(), this.interval)
-    log('Starting bootstrap node discovery')
-    this._discoverBootstrapPeers()
+    log('Starting bootstrap node discovery, discovering peers after %s ms', this.timeout)
+    this.timer = setTimeout(() => {
+      void this._discoverBootstrapPeers()
+        .catch(err => {
+          log.error(err)
+        })
+    }, this.timeout)
   }
 
   /**
    * Emit each address in the list as a PeerInfo
    */
-  _discoverBootstrapPeers () {
+  async _discoverBootstrapPeers () {
     if (this.timer == null) {
       return
     }
 
-    this.list.forEach((peerData) => {
+    for (const peerData of this.list) {
+      await this.components.getPeerStore().tagPeer(peerData.id, this._init.tagName ?? DEFAULT_BOOTSTRAP_TAG_NAME, {
+        value: this._init.tagValue ?? DEFAULT_BOOTSTRAP_TAG_VALUE,
+        ttl: this._init.tagTTL ?? DEFAULT_BOOTSTRAP_TAG_TTL
+      })
+
+      // check we are still running
+      if (this.timer == null) {
+        return
+      }
+
       this.dispatchEvent(new CustomEvent<PeerInfo>('peer', { detail: peerData }))
-    })
+    }
   }
 
   /**
@@ -107,7 +150,7 @@ export class Bootstrap extends EventEmitter<PeerDiscoveryEvents> implements Peer
    */
   stop () {
     if (this.timer != null) {
-      clearInterval(this.timer)
+      clearTimeout(this.timer)
     }
 
     this.timer = undefined

--- a/test/compliance.spec.ts
+++ b/test/compliance.spec.ts
@@ -3,14 +3,26 @@
 import tests from '@libp2p/interface-peer-discovery-compliance-tests'
 import { Bootstrap } from '../src/index.js'
 import peerList from './fixtures/default-peers.js'
+import { Components } from '@libp2p/components'
+import { PersistentPeerStore } from '@libp2p/peer-store'
+import { MemoryDatastore } from 'datastore-core'
 
 describe('compliance tests', () => {
   tests({
     async setup () {
+      const datastore = new MemoryDatastore()
+      const peerStore = new PersistentPeerStore()
+      const components = new Components({
+        peerStore,
+        datastore
+      })
+      peerStore.init(components)
+
       const bootstrap = new Bootstrap({
         list: peerList,
-        interval: 2000
+        timeout: 100
       })
+      bootstrap.init(components)
 
       return bootstrap
     },


### PR DESCRIPTION
Bootstrap peers should be used in an intial DHT self query to find peers that are KAD-close to us.

We do not need to rediscover the same peers over and over again, instead we should just discover them once, use them to query for peers near our PeerId then we can disconnect from them like any other peer

1. Instead of "discovering" the same peers every few seconds, only discover them once
2. Tag the peers in the peer store with an expiring value to prevent any potential connection being culled before we've used the bootstrap nodes to query for peers close to us

BREAKING CHANGE: the `interval` option has been renamed `timeout` and peers are now only discovered once