### PR TITLE
fix!: remove @libp2p/components

### DIFF
--- a/package.json
+++ b/package.json
@@ -138,9 +138,9 @@
     "release": "aegir release"
   },
   "dependencies": {
-    "@libp2p/components": "^3.0.0",
     "@libp2p/interface-peer-discovery": "^1.0.1",
     "@libp2p/interface-peer-info": "^1.0.3",
+    "@libp2p/interface-peer-store": "^1.2.2",
     "@libp2p/interfaces": "^3.0.3",
     "@libp2p/logger": "^2.0.1",
     "@libp2p/peer-id": "^1.1.15",
@@ -148,9 +148,9 @@
     "@multiformats/multiaddr": "^11.0.0"
   },
   "devDependencies": {
-    "@libp2p/interface-peer-discovery-compliance-tests": "^1.0.2",
+    "@libp2p/interface-peer-discovery-compliance-tests": "^2.0.0",
     "@libp2p/interface-peer-id": "^1.0.4",
-    "@libp2p/peer-store": "^4.0.0",
+    "@libp2p/peer-store": "^5.0.0",
     "aegir": "^37.5.3",
     "datastore-core": "^8.0.1",
     "delay": "^5.0.0"

--- a/package.json
+++ b/package.json
@@ -150,6 +150,7 @@
   "devDependencies": {
     "@libp2p/interface-peer-discovery-compliance-tests": "^2.0.0",
     "@libp2p/interface-peer-id": "^1.0.4",
+    "@libp2p/peer-id-factory": "^1.0.18",
     "@libp2p/peer-store": "^5.0.0",
     "aegir": "^37.5.3",
     "datastore-core": "^8.0.1",

--- a/test/compliance.spec.ts
+++ b/test/compliance.spec.ts
@@ -1,7 +1,7 @@
 /* eslint-env mocha */
 
 import tests from '@libp2p/interface-peer-discovery-compliance-tests'
-import { Bootstrap } from '../src/index.js'
+import { bootstrap } from '../src/index.js'
 import peerList from './fixtures/default-peers.js'
 import { Components } from '@libp2p/components'
 import { PersistentPeerStore } from '@libp2p/peer-store'
@@ -18,13 +18,10 @@ describe('compliance tests', () => {
       })
       peerStore.init(components)
 
-      const bootstrap = new Bootstrap({
+      return bootstrap({
         list: peerList,
         timeout: 100
-      })
-      bootstrap.init(components)
-
-      return bootstrap
+      })(components)
     },
     async teardown () {}
   })

--- a/test/compliance.spec.ts
+++ b/test/compliance.spec.ts
@@ -3,20 +3,19 @@
 import tests from '@libp2p/interface-peer-discovery-compliance-tests'
 import { bootstrap } from '../src/index.js'
 import peerList from './fixtures/default-peers.js'
-import { Components } from '@libp2p/components'
 import { PersistentPeerStore } from '@libp2p/peer-store'
 import { MemoryDatastore } from 'datastore-core'
+import { createEd25519PeerId } from '@libp2p/peer-id-factory'
 
 describe('compliance tests', () => {
   tests({
     async setup () {
-      const datastore = new MemoryDatastore()
-      const peerStore = new PersistentPeerStore()
-      const components = new Components({
-        peerStore,
-        datastore
-      })
-      peerStore.init(components)
+      const components = {
+        peerStore: new PersistentPeerStore({
+          peerId: await createEd25519PeerId(),
+          datastore: new MemoryDatastore()
+        })
+      }
 
       return bootstrap({
         list: peerList,


### PR DESCRIPTION
`@libp2p/components` is a choke-point for our dependency graph as it depends on every interface, meaning when one interface revs a major `@libp2p/components` major has to change too which means every module depending on it also needs a major.

Switch instead to constructor injection of simple objects that let modules declare their dependencies on interfaces directly instead of indirectly via `@libp2p/components`

Refs https://github.com/libp2p/js-libp2p-components/issues/6

BREAKING CHANGE: modules no longer implement `Initializable` instead switching to constructor injection