### PR TITLE
fix!: update multiformats to v11

### DIFF
--- a/package.json
+++ b/package.json
@@ -140,20 +140,20 @@
   },
   "dependencies": {
     "@libp2p/interface-peer-discovery": "^1.0.1",
-    "@libp2p/interface-peer-info": "^1.0.3",
+    "@libp2p/interface-peer-info": "^1.0.7",
     "@libp2p/interface-peer-store": "^1.2.2",
     "@libp2p/interfaces": "^3.0.3",
     "@libp2p/logger": "^2.0.1",
-    "@libp2p/peer-id": "^1.1.15",
+    "@libp2p/peer-id": "^2.0.0",
     "@multiformats/mafmt": "^11.0.3",
     "@multiformats/multiaddr": "^11.0.0"
   },
   "devDependencies": {
     "@libp2p/interface-peer-discovery-compliance-tests": "^2.0.0",
-    "@libp2p/interface-peer-id": "^1.0.4",
-    "@libp2p/peer-id-factory": "^1.0.18",
-    "@libp2p/peer-store": "^5.0.0",
-    "aegir": "^37.7.5",
+    "@libp2p/interface-peer-id": "^2.0.0",
+    "@libp2p/peer-id-factory": "^2.0.0",
+    "@libp2p/peer-store": "^6.0.0",
+    "aegir": "^37.9.1",
     "datastore-core": "^8.0.1",
     "delay": "^5.0.0"
   }


### PR DESCRIPTION
The CID class has breaking changes in v11 so update all deps to use the new version